### PR TITLE
Collect unique recipes

### DIFF
--- a/cmd/allrecipes/main.go
+++ b/cmd/allrecipes/main.go
@@ -72,7 +72,9 @@ func main() {
 
 		// recursively visit recipe pages shown in section "You'll Also Love"
 		for _, url := range e.ChildAttrs(".recirc-section a", "href") {
-			e.Request.Visit(url)
+			if !recipes.Exists(url) {
+				e.Request.Visit(url) // visit only if the url is new
+			}
 		}
 	})
 

--- a/internal/apps/allrecipes/recipe.go
+++ b/internal/apps/allrecipes/recipe.go
@@ -47,7 +47,7 @@ type Recipes struct {
 	mux     sync.Mutex
 }
 
-// Add adds a given recipe to the recipes map if not yet added
+// Add adds a given recipe to the data store if not yet added
 func (recipes *Recipes) Add(recipe *Recipe) {
 	recipes.mux.Lock()
 	if recipes.recipes == nil {
@@ -58,6 +58,14 @@ func (recipes *Recipes) Add(recipe *Recipe) {
 		recipes.recipes[recipe.URL] = *recipe
 	}
 	recipes.mux.Unlock()
+}
+
+// Exists checks if the url exists in the data store
+func (recipes *Recipes) Exists(url string) bool {
+	recipes.mux.Lock()
+	_, ok := recipes.recipes[url]
+	recipes.mux.Unlock()
+	return ok
 }
 
 // DumpJSON dumps the recipes into a json file


### PR DESCRIPTION
Previously, the recipes already collected were visited and stored again.

This PR fixes these by changing the datastore type from array to map, and verifying if the URL has not been added to the map before making a request.